### PR TITLE
Restore Human Detection: add simulation launch handler (start_simulat…

### DIFF
--- a/exercises/views.py
+++ b/exercises/views.py
@@ -89,3 +89,17 @@ def user_code_zip(request, exercise_id):
 
     except Exception as e:
         return Response({"success": False, "message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+def start_simulation(request, exercise_id):
+    try:
+        exercise_path = os.path.join(settings.BASE_DIR, f"exercises/static/exercises/{exercise_id}/launch.sh")
+
+        # Make sure launch.sh is executable
+        subprocess.call(["chmod", "+x", exercise_path])
+
+        # Launch the simulator in the background
+        subprocess.Popen(["bash", exercise_path])
+
+        return JsonResponse({"status": "started"})
+    except Exception as e:
+        return JsonResponse({"status": "error", "message": str(e)})


### PR DESCRIPTION
…ion)

This commit adds a new start_simulation view function to the views.py file to help restore the Human Detection exercise.

The new function dynamically builds the path to the launch.sh script inside the exercise directory and ensures it is executable.

It then starts the simulator using subprocess.Popen, allowing the backend process to launch in the background.

This mirrors the approach used in working exercises like digit_classifier, where simulation launch is handled on the backend.

This change aims to resolve the reported issue (#1500), where the connection fails unless the terminal is manually reset. Automating the launch through this function ensures a clean and consistent start every time.

Next steps involve making sure this route is triggered by the frontend when the exercise starts.